### PR TITLE
rename some types to work around injective type family stuff

### DIFF
--- a/src/Data/FixedSize/Vector.hs
+++ b/src/Data/FixedSize/Vector.hs
@@ -100,7 +100,7 @@ nil = Vector VS.empty
 -- >>> cons False (cons True nil)
 -- [False,True]
 --
-cons :: forall a n. a -> Vector n a -> Vector (n + 1) a
+cons :: forall a n. a -> Vector n a -> Vector (1 + n) a
 cons x (Vector xs) = Vector $ VS.cons x xs
 
 -- | Gets the first element of a vector of length greater than zero.
@@ -108,7 +108,7 @@ cons x (Vector xs) = Vector $ VS.cons x xs
 -- >>> vhead (cons 'x' (cons 'y' nil))
 -- 'x'
 --
-vhead :: Vector (n + 1) a -> a
+vhead :: Vector (1 + n) a -> a
 vhead (Vector v) = VS.head v
 
 -- | For a vector of length greater than zero, gets the vector with its first element removed.
@@ -116,7 +116,7 @@ vhead (Vector v) = VS.head v
 -- >>> vtail (cons 'x' (cons 'y' nil))
 -- "y"
 --
-vtail :: forall a n. Vector (n + 1) a -> Vector n a
+vtail :: forall a n. Vector (1 + n) a -> Vector n a
 vtail (Vector v) = Vector $ VS.tail v
 
 infixl 6 <+>

--- a/src/Numeric/Neural/Layer.hs
+++ b/src/Numeric/Neural/Layer.hs
@@ -43,7 +43,7 @@ import Prelude                 hiding (id, (.))
 --
 type Layer i o = Component (Vector i) (Vector o)
 
-linearLayer' :: forall i o s. Analytic s => ParamFun s (Matrix o (i + 1)) (Vector i s) (Vector o s)
+linearLayer' :: forall i o s. Analytic s => ParamFun s (Matrix o (1 + i)) (Vector i s) (Vector o s)
 linearLayer' = ParamFun $ \xs ws -> ws <%%> cons 1 xs
 
 -- | Creates a /linear/ @'Layer'@, i.e. a layer that multiplies the input with a weight @'Matrix'@ and adds a bias to get the output.
@@ -51,7 +51,7 @@ linearLayer' = ParamFun $ \xs ws -> ws <%%> cons 1 xs
 --   Random initialization follows the recommendation from chapter 3 of the online book
 --   <http://neuralnetworksanddeeplearning.com/ Neural Networks and Deep Learning> by Michael Nielsen.
 linearLayer :: forall i o. (KnownNat i, KnownNat o) => Layer i o
-linearLayer = withNatOp (%+) p (Proxy :: Proxy 1) Component
+linearLayer = withNatOp (%+) (Proxy :: Proxy 1) p Component
     { weights = pure 0
     , compute = linearLayer'
     , initR   = sequenceA $ generate r


### PR DESCRIPTION
this is really not the right way to address this issue probably, but it seems to work fine for now. This should fix #3 just get things working, but it seems to have some deeper issue related to/that might be fixed by https://ghc.haskell.org/trac/ghc/wiki/InjectiveTypeFamilies