### PR TITLE
Added convolutional neural network (CNN) for MNIST digit classification.

### DIFF
--- a/examples/MNIST/MNIST_cnn.hs
+++ b/examples/MNIST/MNIST_cnn.hs
@@ -27,7 +27,8 @@ main = flip evalRandT (mkStdGen 999999) $ do
     liftIO $ printf "\ngeneration  learning rate  batch error\n\n"
     (a, g) <- runEffect $
             cachingBatchP getSamples 60000 20 2000 100
-        >-> descentP m 1 (\g -> 0.1 * 100 / (100 + fromIntegral g))
+        -- >-> descentP m 1 (\g -> 0.05 * 100 / (100 + fromIntegral g))
+        >-> descentP m 1 (\g -> 0.05)
         >-> reportTSP 1 report
         >-> consumeTSP check
     liftIO $ printf "\nreached accuracy of %f after %d generations\n" a g
@@ -103,18 +104,18 @@ type MNISTModel = Classifier (Matrix 28 28) 10 Img Digit
 mnistModel :: MNISTModel
 mnistModel = mkStdClassifier c i where
 
-    -- c = reLULayer
-    --   . cArr (Diff toVector)
-    --   . (maxPool (Proxy :: DP.Proxy 4) 4               :: Component (Volume  4  4 32) (Volume  1  1 32))
-    --   . (convolution (Proxy :: DP.Proxy 3) 1 reLULayer :: Component (Volume  6  6 16) (Volume  4  4 32))
-    --   . (maxPool (Proxy :: DP.Proxy 4) 4               :: Component (Volume 24 24 16) (Volume  6  6 16))
-    --   . (convolution (Proxy :: DP.Proxy 5) 1 reLULayer :: Component (Volume 28 28  1) (Volume 24 24 16))
-    --   . cArr (Diff fromMatrix)
-
     c = reLULayer
       . cArr (Diff toVector)
-      . (convolution (Proxy :: DP.Proxy 7) 3 reLULayer :: Component (Volume 28 28  1) (Volume 8 8 4))
+      . (maxPool (Proxy :: DP.Proxy 4) 4               :: Component (Volume  4  4 32) (Volume  1  1 32))
+      . (convolution (Proxy :: DP.Proxy 3) 1 reLULayer :: Component (Volume  6  6 16) (Volume  4  4 32))
+      . (maxPool (Proxy :: DP.Proxy 4) 4               :: Component (Volume 24 24 16) (Volume  6  6 16))
+      . (convolution (Proxy :: DP.Proxy 5) 1 reLULayer :: Component (Volume 28 28  1) (Volume 24 24 16))
       . cArr (Diff fromMatrix)
+
+    -- c = reLULayer
+    --   . cArr (Diff toVector)
+    --   . (convolution (Proxy :: DP.Proxy 7) 3 reLULayer :: Component (Volume 28 28  1) (Volume 8 8 4))
+    --   . cArr (Diff fromMatrix)
 
     i img = let m = generate $ \(x, y) -> fromIntegral (pixelAt img x y) in force m
 

--- a/examples/MNIST/MNIST_cnn.hs
+++ b/examples/MNIST/MNIST_cnn.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+module Main where
+
+import           Codec.Picture
+import           Control.Category
+import qualified Data.Array       as A
+import           Data.MyPrelude
+import           Data.Proxy       as DP
+import           Data.Utils
+-- import           GHC.TypeLits     as TL
+import           Numeric.Neural
+import           Pipes.GZip       (decompress)
+import qualified Pipes.Prelude    as P
+import           Prelude          hiding (id, (.))
+
+main :: IO ()
+main = flip evalRandT (mkStdGen 999999) $ do
+    xs     <- getSamples [0 .. 999]
+    m      <- modelR (whiten mnistModel $ fst <$> xs)
+    liftIO $ printf "\ngeneration  learning rate  batch error\n\n"
+    (a, g) <- runEffect $
+            cachingBatchP getSamples 60000 20 2000 100
+        >-> descentP m 1 (\g -> 0.4 * 100 / (100 + fromIntegral g))
+        >-> reportTSP 1 report
+        >-> consumeTSP check
+    liftIO $ printf "\nreached accuracy of %f after %d generations\n" a g
+
+  where
+
+    getSamples xs = liftIO $ runSafeT $ P.toListM $ trainSamples >-> indicesP xs
+
+    report ts = liftIO $ do
+        let g = tsGeneration ts
+        when (g `mod` 5 == 0) $ printf "   %7d       %8.6f   %10.8f\n" g (tsEta ts) (tsBatchError ts)
+
+    check ts = do
+        let g = tsGeneration ts
+        if g `mod` 50 == 0
+            then do
+                a <- liftIO $ accuracy $ tsModel ts
+                liftIO $ printf "\naccuracy %f\n\n" a
+                {- This doesn't work, due to the existentially quantified type of *weights*.
+                case (tsModel ts) ^. _component of
+                  Component{..} ->
+                    liftIO $ putStrLn $ "weights: " ++ show weights -}
+                return $ if a > 0.9 then Just (a, g) else Nothing
+            else return Nothing
+
+accuracy :: MNISTModel -> IO Double
+accuracy m = runSafeT $ fromJust <$> classifierAccuracyP m testSamples
+
+type Img = Image Pixel8
+
+data Digit = Zero | One | Two | Three | Four | Five | Six | Seven | Eight | Nine
+    deriving (Show, Read, Eq, Ord, Enum, Bounded)
+
+type Sample = (Img, Digit)
+
+trainImagesFile, trainLabelsFile, testImagesFile, testLabelsFile :: FilePath
+trainImagesFile = "examples" </> "MNIST" </> "train-images-idx3-ubyte" <.> "gz"
+trainLabelsFile = "examples" </> "MNIST" </> "train-labels-idx1-ubyte" <.> "gz"
+testImagesFile  = "examples" </> "MNIST" </> "t10k-images-idx3-ubyte"  <.> "gz"
+testLabelsFile  = "examples" </> "MNIST" </> "t10k-labels-idx1-ubyte"  <.> "gz"
+
+bytes :: MonadSafe m => FilePath -> Producer Word8 m ()
+bytes f = decompress (fromFile f) >-> toWord8
+
+labels :: MonadSafe m => FilePath -> Producer Digit m ()
+labels f = bytes f >-> P.drop 8 >-> P.map (toEnum . fromIntegral)
+
+images :: MonadSafe m => FilePath -> Producer Img m ()
+images f = bytes f >-> P.drop 16 >-> chunks (28 * 28) >-> P.map g
+
+  where
+
+    g xs = let a = A.listArray ((0, 0), (27, 27)) xs
+           in  generateImage (\x y -> 255 - a A.! (y, x)) 28 28
+
+trainSamples, testSamples :: MonadSafe m => Producer Sample m ()
+trainSamples = P.zip (images trainImagesFile) (labels trainLabelsFile)
+testSamples  = P.zip (images testImagesFile)  (labels testLabelsFile)
+
+writeImg :: MonadIO m => FilePath -> Img -> m ()
+writeImg f i = liftIO $ saveTiffImage (f <.> "tiff") (ImageY8 i)
+
+type MNISTModel = Classifier (Matrix 28 28) 10 Img Digit
+
+mnistModel :: MNISTModel
+mnistModel = mkStdClassifier c i where
+
+    c = reLULayer
+      . cArr (Diff toVector)
+      . (maxPool (Proxy :: DP.Proxy 4) 4               :: Component (Volume  4  4 32) (Volume  1  1 32))
+      . (convolution (Proxy :: DP.Proxy 3) 1 reLULayer :: Component (Volume  6  6 16) (Volume  4  4 32))
+      . (maxPool (Proxy :: DP.Proxy 4) 4               :: Component (Volume 24 24 16) (Volume  6  6 16))
+      . (convolution (Proxy :: DP.Proxy 5) 1 reLULayer :: Component (Volume 28 28  1) (Volume 24 24 16))
+      . cArr (Diff fromMatrix)
+
+    i img = let m = generate $ \(x, y) -> fromIntegral (pixelAt img x y) in force m
+

--- a/neural.cabal
+++ b/neural.cabal
@@ -194,6 +194,7 @@ executable MNIST_cnn
                      , neural
                      , pipes
                      , pipes-zlib
+                     , vector
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N -fexcess-precision -optc-O3 -optc-ffast-math
   default-language:    Haskell2010
 

--- a/neural.cabal
+++ b/neural.cabal
@@ -185,6 +185,18 @@ executable MNIST
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N -fexcess-precision -optc-O3 -optc-ffast-math
   default-language:    Haskell2010
 
+executable MNIST_cnn
+  hs-source-dirs:      examples/MNIST
+  main-is:             MNIST_cnn.hs
+  build-depends:       base >= 4.7 && < 5
+                     , array
+                     , JuicyPixels
+                     , neural
+                     , pipes
+                     , pipes-zlib
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N -fexcess-precision -optc-O3 -optc-ffast-math
+  default-language:    Haskell2010
+
 source-repository head
   type:     git
   location: https://github.com/brunjlar/neural.git

--- a/src/Numeric/Neural/Convolution.hs
+++ b/src/Numeric/Neural/Convolution.hs
@@ -115,14 +115,12 @@ maxPool :: forall s m n d m' n'.
                => Proxy s              -- ^ a proxy to the region size
                -> Int                  -- ^ the stride
                -> Component (Volume m n d) (Volume m' n' d)
--- maxPool ps stride = cArr (Diff $ toVolume . unCompose) .
 maxPool ps stride =
   cArr (Diff $ toVolume . unCompose) .
-    cArr (Diff $ Compose . fmap (maxReduce (fromIntegral ((natVal (Proxy :: Proxy s)) ^ 2))) . unCompose) .
+  cArr (Diff $ Compose . fmap (maxReduce (fromIntegral ((natVal (Proxy :: Proxy s)) ^ 2))) . unCompose) .
   cArr (Diff $ Compose . cover' ps stride)
   where
-    maxReduce ::
-         (Foldable f, Applicative g, Traversable g, Ord a) => Int -> f a -> g a
+    maxReduce :: (Foldable f, Applicative g, Traversable g, Ord a) => Int -> f a -> g a
     maxReduce step = fromJust . fromList . maxReduce' step . toList
     maxReduce' _ [] = []
     maxReduce' step xs =

--- a/src/Numeric/Neural/Model.hs
+++ b/src/Numeric/Neural/Model.hs
@@ -41,7 +41,6 @@ module Numeric.Neural.Model
     , cFirst
     , cLeft
     , cConvolve
-    -- , cMax
     , Model(..)
     , _component
     , model
@@ -57,7 +56,6 @@ import Control.Arrow
 import Control.Category
 import Control.Monad.Par            (runPar)
 import Control.Monad.Par.Combinator (parMapReduceRange, InclusiveRange(..))
--- import Data.Foldable                (maximum)
 import Data.Functor.Compose         (Compose(..))
 import Data.Functor.Product         (Product(..))
 import Data.Functor.Sum             (Sum(..))
@@ -189,22 +187,6 @@ cConvolve (Component ws c i) = Component
     , compute = ParamFun $ \(Compose xss) ws' -> Compose $ flip (runPF c) ws' <$> xss
     , initR   = i
     }
-
--- | The analogue of 'max' for 'Component's.
---
--- cMax :: (Functor h, Foldable f) => Component (Compose h f) (Compose h g)
--- cMax :: (Functor h, Foldable f) => Component (Compose h f) h
--- cMax = Component
---     { weights = Empty
---     , compute = ParamFun $ \ (Compose xss) _ -> maximum <$> xss
---     , initR   = return Empty
---     }
--- newtype ParamFun s t a b = ParamFun { runPF :: a -> t s -> b }
--- data Component f g = forall t. (Traversable t, Applicative t, NFData (t Double)) => Component
---     { weights :: t Double                                         -- ^ the specific parameter values
---     , compute :: forall s. Analytic s => ParamFun s t (f s) (g s) -- ^ the encapsulated parameterized function
---     , initR   :: forall m. MonadRandom m => m (t Double)          -- ^ randomly sets the parameters
---     }
 
 instance NFData (Component f g) where
 

--- a/src/Numeric/Neural/Model.hs
+++ b/src/Numeric/Neural/Model.hs
@@ -41,6 +41,7 @@ module Numeric.Neural.Model
     , cFirst
     , cLeft
     , cConvolve
+    -- , cMax
     , Model(..)
     , _component
     , model
@@ -56,6 +57,7 @@ import Control.Arrow
 import Control.Category
 import Control.Monad.Par            (runPar)
 import Control.Monad.Par.Combinator (parMapReduceRange, InclusiveRange(..))
+-- import Data.Foldable                (maximum)
 import Data.Functor.Compose         (Compose(..))
 import Data.Functor.Product         (Product(..))
 import Data.Functor.Sum             (Sum(..))
@@ -187,6 +189,22 @@ cConvolve (Component ws c i) = Component
     , compute = ParamFun $ \(Compose xss) ws' -> Compose $ flip (runPF c) ws' <$> xss
     , initR   = i
     }
+
+-- | The analogue of 'max' for 'Component's.
+--
+-- cMax :: (Functor h, Foldable f) => Component (Compose h f) (Compose h g)
+-- cMax :: (Functor h, Foldable f) => Component (Compose h f) h
+-- cMax = Component
+--     { weights = Empty
+--     , compute = ParamFun $ \ (Compose xss) _ -> maximum <$> xss
+--     , initR   = return Empty
+--     }
+-- newtype ParamFun s t a b = ParamFun { runPF :: a -> t s -> b }
+-- data Component f g = forall t. (Traversable t, Applicative t, NFData (t Double)) => Component
+--     { weights :: t Double                                         -- ^ the specific parameter values
+--     , compute :: forall s. Analytic s => ParamFun s t (f s) (g s) -- ^ the encapsulated parameterized function
+--     , initR   :: forall m. MonadRandom m => m (t Double)          -- ^ randomly sets the parameters
+--     }
 
 instance NFData (Component f g) where
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,7 @@
 flags: {}
+nix:
+  enable: false
+  shell-file: shell.nix
 extra-package-dbs: []
 packages:
 - .
@@ -7,7 +10,4 @@ extra-deps:
 - pipes-4.2.0
 - pipes-safe-2.2.4
 - pipes-zlib-0.4.4.1
-resolver: lts-9.0
-nix:
-    enable: false
-    shell-file: shell.nix
+resolver: lts-9.6


### PR DESCRIPTION
This pull request adds a convolutional neural network (CNN) for MNIST digit classification.

There are actually two CNN models included in the new _examples/MNIST/MNIST_cnn.hs_ file:

- A complex model, composed of two convolutional layers, both using a _maxPool_ operation to condense their outputs.
    This model doesn't work (It doesn't learn.). And it is, currently, commented out in the code. It is my hope to get it working soon.

- A simple model, using a single convolutional layer and no maxPooling.
    This model achieves 90% accuracy after 550 generations.

The new executable is called _MNIST_cnn_.

I run it, like this:

    stack build
    stack exec MNIST_cnn
